### PR TITLE
convert template files to go files and use strings instead of files

### DIFF
--- a/bindings/fcl-js_test.go
+++ b/bindings/fcl-js_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hexops/autogold/v2"
 	"github.com/onflow/flixkit-go"
+	bindings "github.com/onflow/flixkit-go/bindings/templates"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -193,7 +194,11 @@ var minimumNoParamTemplate = &flixkit.FlowInteractionTemplate{
 
 func TestJSGenTransaction(t *testing.T) {
 	generator := FclJSGenerator{
-		TemplateDir: "./templates",
+		Templates: []string{
+			bindings.GetJsFclMainTemplate(),
+			bindings.GetJsFclScriptTemplate(),
+			bindings.GetJsFclTxTemplate(),
+		},
 	}
 	got, _ := generator.Generate(parsedTemplateTX, "./transfer_token.json", true)
 	autogold.ExpectFile(t, got)
@@ -201,7 +206,11 @@ func TestJSGenTransaction(t *testing.T) {
 
 func TestJSGenScript(t *testing.T) {
 	generator := FclJSGenerator{
-		TemplateDir: "./templates",
+		Templates: []string{
+			bindings.GetJsFclMainTemplate(),
+			bindings.GetJsFclScriptTemplate(),
+			bindings.GetJsFclTxTemplate(),
+		},
 	}
 	assert := assert.New(t)
 	got, err := generator.Generate(parsedTemplateScript, "./multiply_two_integers.template.json", true)
@@ -211,7 +220,11 @@ func TestJSGenScript(t *testing.T) {
 
 func TestJSGenArrayScript(t *testing.T) {
 	generator := FclJSGenerator{
-		TemplateDir: "./templates",
+		Templates: []string{
+			bindings.GetJsFclMainTemplate(),
+			bindings.GetJsFclScriptTemplate(),
+			bindings.GetJsFclTxTemplate(),
+		},
 	}
 	assert := assert.New(t)
 

--- a/bindings/templates/js_fcl_main.tmpl.go
+++ b/bindings/templates/js_fcl_main.tmpl.go
@@ -1,4 +1,7 @@
-/**
+package bindings
+
+func GetJsFclMainTemplate() string {
+	const template = `/**
     This binding file was auto generated based on FLIX template v{{.Version}}. 
     Changes to this file might get overwritten.
     Note fcl version 1.3.0 or higher is required to use templates. 
@@ -25,10 +28,15 @@ const flixTemplate = "{{.Location}}"
  {{- end -}}
 {{- "\n"}}*/
 {{if .IsScript}}
-{{- template "js_fcl_script.tmpl" .}}
+{{- template "script" .}}
 {{else}}
-{{- template "js_fcl_tx.tmpl" .}}
+{{- template "tx" .}}
 {{- end}}
 
 
 
+
+`
+
+	return template
+}

--- a/bindings/templates/js_fcl_script.tmpl.go
+++ b/bindings/templates/js_fcl_script.tmpl.go
@@ -1,4 +1,7 @@
-export async function {{.Title}}( 
+package bindings
+
+func GetJsFclScriptTemplate() string {
+	const template = `{{define "script"}}export async function {{.Title}}( 
  {{- if len .Parameters -}}
   {
     {{- range $index, $ele := .Parameters -}}
@@ -19,4 +22,9 @@ export async function {{.Title}}(
   });
 
   return info
+}{{end}}
+`
+
+	return template
+
 }

--- a/bindings/templates/js_fcl_tx.tmpl.go
+++ b/bindings/templates/js_fcl_tx.tmpl.go
@@ -1,4 +1,7 @@
-export async function {{.Title}}({ 
+package bindings
+
+func GetJsFclTxTemplate() string {
+	const template = `{{define "tx"}}export async function {{.Title}}({ 
  {{- if len .Parameters -}}
     {{- range $index, $ele := .Parameters -}}
       {{if $index}}, {{end}}{{.Name}}
@@ -17,4 +20,9 @@ export async function {{.Title}}({
   });
 
   return transactionId
+}{{end}}
+`
+
+	return template
+
 }


### PR DESCRIPTION
Fix bug where template files are not shipped with bindings module in flixkit-go version.

Convert template text files to go files. 

fixes https://github.com/onflow/flixkit-go/issues/23

will need to release a patch