### PR TITLE
Update processing of Cadence pragma information

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ fmt.Println(prettyJSON)
 ```
 ### Cadence docs pragma
 
-> Using Cadence pragma the metadata can live with the Cadence code. Therefore a prefilled template isn't necessary
+> Using Cadence pragma the metadata can live with the Cadence code. Therefore a prefilled template isn't necessary. More information [Cadence Doc FLIP](https://github.com/onflow/flips/blob/main/application/20230406-interaction-template-cadence-doc.md)
 
 ### Example
 
@@ -113,21 +113,18 @@ fmt.Println(prettyJSON)
 		version: "1.1.0",
 		title: "Transfer Flow",
 		description: "Transfer Flow to account",
-		language: "en-US",
-		parameters: [
-			Parameter(
-				name: "amount", 
-				title: "Amount", 
-				description: "Amount of Flow to transfer"
-			),
-			Parameter(
-				name: "to", 
-				title: "Reciever", 
-				description: "Destination address to receive Flow Tokens"
-			)
-		],
+		language: "en-US",	
 	)
-	
+#interaction-param-amount(
+        title: "Amount", 
+        description: "Amount of Flow to transfer",
+		language: "en-US",
+)	
+#interaction-param-to(
+		title: "Reciever", 
+		description: "Destination address to receive Flow Tokens",
+		language: "en-US",
+)
 	import "FlowToken"
 	transaction(amount: UFix64, to: Address) {
 		let vault: @FlowToken.Vault

--- a/flixkit/fcl_bindings_test.go
+++ b/flixkit/fcl_bindings_test.go
@@ -367,7 +367,7 @@ var minimumParamTemplateTS_TX = &v1_1.InteractionTemplate{
 		Type:      "transaction",
 		Interface: "",
 		Cadence: v1_1.Cadence{
-			Body:        "import \"HelloWorld\"\n\n#interaction (\n  version: \"1.1.0\",\n\ttitle: \"Update Greeting\",\n\tdescription: \"Update the greeting on the HelloWorld contract\",\n\tlanguage: \"en-US\",\n\tparameters: [\n\t\tParameter(\n\t\t\tname: \"greeting\", \n\t\t\ttitle: \"Greeting\", \n\t\t\tdescription: \"The greeting to set on the HelloWorld contract\"\n\t\t)\n\t],\n)\ntransaction(greeting: String) {\n\n  prepare(acct: AuthAccount) {\n    log(acct.address)\n  }\n\n  execute {\n    HelloWorld.updateGreeting(newGreeting: greeting)\n  }\n}\n",
+			Body:        "import \"HelloWorld\"\n\n#interaction (\n  version: \"1.1.0\",\n\ttitle: \"Update Greeting\",\n\tdescription: \"Update the greeting on the HelloWorld contract\",\n\tlanguage: \"en-US\",\n)\ntransaction(greeting: String) {\n\n  prepare(acct: AuthAccount) {\n    log(acct.address)\n  }\n\n  execute {\n    HelloWorld.updateGreeting(newGreeting: greeting)\n  }\n}\n",
 			NetworkPins: []v1_1.NetworkPin{},
 		},
 		Messages: []v1_1.Message{

--- a/flixkit/generator.go
+++ b/flixkit/generator.go
@@ -117,12 +117,12 @@ func (g Generator) Generate(ctx context.Context, code string, preFill string) (s
 		return "", err
 	}
 
-	err = g.template.ParsePragma(program)
+	err = g.template.ProcessParameters(program)
 	if err != nil {
 		return "", err
 	}
 
-	err = g.template.ProcessParameters(program)
+	err = g.template.ParsePragma(program)
 	if err != nil {
 		return "", err
 	}

--- a/flixkit/generator_test.go
+++ b/flixkit/generator_test.go
@@ -44,7 +44,6 @@ func TestHelloScript(t *testing.T) {
 		title: "Say Hello",
 		description: "Read the greeting from the HelloWorld contract",
 		language: "en-US",
-		parameters: [],
 	)
 	
 	import "HelloWorld"
@@ -93,13 +92,12 @@ func TestTransactionValue(t *testing.T) {
 		title: "Update Greeting",
 		description: "Update the greeting on the HelloWorld contract",
 		language: "en-US",
-		parameters: [
-			Parameter(
-				name: "greeting", 
-				title: "Greeting", 
-				description: "The greeting to set on the HelloWorld contract"
-			)
-		],
+	)
+
+	#interaction_param_greeting(
+		title: "Greeting",
+		description: "The greeting to set on the HelloWorld contract",
+		language: "en-US",
 	)
 	
 	import "HelloWorld"
@@ -148,18 +146,18 @@ func TestTransferFlowTransaction(t *testing.T) {
 		title: "Transfer Flow",
 		description: "Transfer Flow to account",
 		language: "en-US",
-		parameters: [
-			Parameter(
-				name: "amount", 
-				title: "Amount", 
-				description: "Amount of Flow to transfer"
-			),
-			Parameter(
-				name: "to", 
-				title: "Reciever", 
-				description: "Destination address to receive Flow Tokens"
-			)
-		],
+	)
+
+	#interaction_param_amount(
+		title: "Amount",
+		description: "Amount of Flow to transfer",
+		language: "en-US",
+	)
+
+	#interaction_param_to(
+		title: "Reciever",
+		description: "Destination address to receive Flow Tokens",
+		language: "en-US",
 	)
 	
 	import "FlowToken"

--- a/flixkit/testdata/TestHelloScript.golden
+++ b/flixkit/testdata/TestHelloScript.golden
@@ -26,15 +26,15 @@
             }
         ],
         "cadence": {
-            "body": "\n\t#interaction(\n\t\tversion: \"1.1.0\",\n\t\ttitle: \"Say Hello\",\n\t\tdescription: \"Read the greeting from the HelloWorld contract\",\n\t\tlanguage: \"en-US\",\n\t\tparameters: [],\n\t)\n\t\n\timport \"HelloWorld\"\n\n\tpub fun main(): String {\n\treturn HelloWorld.greeting\n\t}\n",
+            "body": "\n\t#interaction(\n\t\tversion: \"1.1.0\",\n\t\ttitle: \"Say Hello\",\n\t\tdescription: \"Read the greeting from the HelloWorld contract\",\n\t\tlanguage: \"en-US\",\n\t)\n\t\n\timport \"HelloWorld\"\n\n\tpub fun main(): String {\n\treturn HelloWorld.greeting\n\t}\n",
             "network_pins": [
                 {
                     "network": "mainnet",
-                    "pin_self": "57d66cd2e8370ef74feec033e768dc460514091fc82ba1b4c42697b600288048"
+                    "pin_self": "9ca641e8d4077937028b15b16fd50ba347d7d821768ec00b2b7fdf114e898414"
                 },
                 {
                     "network": "testnet",
-                    "pin_self": "57d66cd2e8370ef74feec033e768dc460514091fc82ba1b4c42697b600288048"
+                    "pin_self": "9ca641e8d4077937028b15b16fd50ba347d7d821768ec00b2b7fdf114e898414"
                 }
             ]
         },

--- a/flixkit/testdata/TestTransactionValue.golden
+++ b/flixkit/testdata/TestTransactionValue.golden
@@ -26,15 +26,15 @@
             }
         ],
         "cadence": {
-            "body": "\n\t#interaction(\n\t\tversion: \"1.1.0\",\n\t\ttitle: \"Update Greeting\",\n\t\tdescription: \"Update the greeting on the HelloWorld contract\",\n\t\tlanguage: \"en-US\",\n\t\tparameters: [\n\t\t\tParameter(\n\t\t\t\tname: \"greeting\", \n\t\t\t\ttitle: \"Greeting\", \n\t\t\t\tdescription: \"The greeting to set on the HelloWorld contract\"\n\t\t\t)\n\t\t],\n\t)\n\t\n\timport \"HelloWorld\"\n\ttransaction(greeting: String) {\n\t\n\t\tprepare(acct: AuthAccount) {\n\t\t\tlog(acct.address)\n\t\t}\n\t\t\n\t\texecute {\n\t\t\tHelloWorld.updateGreeting(newGreeting: greeting)\n\t\t}\n\t}\n",
+            "body": "\n\t#interaction(\n\t\tversion: \"1.1.0\",\n\t\ttitle: \"Update Greeting\",\n\t\tdescription: \"Update the greeting on the HelloWorld contract\",\n\t\tlanguage: \"en-US\",\n\t)\n\n\t#interaction_param_greeting(\n\t\ttitle: \"Greeting\",\n\t\tdescription: \"The greeting to set on the HelloWorld contract\",\n\t\tlanguage: \"en-US\",\n\t)\n\t\n\timport \"HelloWorld\"\n\ttransaction(greeting: String) {\n\t\n\t\tprepare(acct: AuthAccount) {\n\t\t\tlog(acct.address)\n\t\t}\n\t\t\n\t\texecute {\n\t\t\tHelloWorld.updateGreeting(newGreeting: greeting)\n\t\t}\n\t}\n",
             "network_pins": [
                 {
                     "network": "mainnet",
-                    "pin_self": "0ad0659f79f7b8336a588e24326c26cf6cf7f74af81c0c8a35ee58e190988af2"
+                    "pin_self": "75e97e50ae3f8f9ec2a33f78f58884504e15b5182c811c33c5eed7fa634b5f09"
                 },
                 {
                     "network": "testnet",
-                    "pin_self": "0ad0659f79f7b8336a588e24326c26cf6cf7f74af81c0c8a35ee58e190988af2"
+                    "pin_self": "75e97e50ae3f8f9ec2a33f78f58884504e15b5182c811c33c5eed7fa634b5f09"
                 }
             ]
         },

--- a/flixkit/testdata/TestTransferFlowTransaction.golden
+++ b/flixkit/testdata/TestTransferFlowTransaction.golden
@@ -26,15 +26,15 @@
             }
         ],
         "cadence": {
-            "body": "\n\t#interaction(\n\t\tversion: \"1.1.0\",\n\t\ttitle: \"Transfer Flow\",\n\t\tdescription: \"Transfer Flow to account\",\n\t\tlanguage: \"en-US\",\n\t\tparameters: [\n\t\t\tParameter(\n\t\t\t\tname: \"amount\", \n\t\t\t\ttitle: \"Amount\", \n\t\t\t\tdescription: \"Amount of Flow to transfer\"\n\t\t\t),\n\t\t\tParameter(\n\t\t\t\tname: \"to\", \n\t\t\t\ttitle: \"Reciever\", \n\t\t\t\tdescription: \"Destination address to receive Flow Tokens\"\n\t\t\t)\n\t\t],\n\t)\n\t\n\timport \"FlowToken\"\n\ttransaction(amount: UFix64, to: Address) {\n\t\tlet vault: @FlowToken.Vault\n\t\tprepare(signer: AuthAccount) {\n\t\t\n\t\t}\n\t}\n",
+            "body": "\n\t#interaction(\n\t\tversion: \"1.1.0\",\n\t\ttitle: \"Transfer Flow\",\n\t\tdescription: \"Transfer Flow to account\",\n\t\tlanguage: \"en-US\",\n\t)\n\n\t#interaction_param_amount(\n\t\ttitle: \"Amount\",\n\t\tdescription: \"Amount of Flow to transfer\",\n\t\tlanguage: \"en-US\",\n\t)\n\n\t#interaction_param_to(\n\t\ttitle: \"Reciever\",\n\t\tdescription: \"Destination address to receive Flow Tokens\",\n\t\tlanguage: \"en-US\",\n\t)\n\t\n\timport \"FlowToken\"\n\ttransaction(amount: UFix64, to: Address) {\n\t\tlet vault: @FlowToken.Vault\n\t\tprepare(signer: AuthAccount) {\n\t\t\n\t\t}\n\t}\n",
             "network_pins": [
                 {
                     "network": "mainnet",
-                    "pin_self": "b11213cf3480f71989f7518791b976cfd80d43c7474495a6d5669b17b77e9346"
+                    "pin_self": "d61dd39581edde6ddc57b760bf6bc155a4d1aa7b95e9b37704952f990bb7abab"
                 },
                 {
                     "network": "testnet",
-                    "pin_self": "d7c8bddb94f640478b573871dfc2c4e9d090c706ab2a7b8c3e8223e5f7f737be"
+                    "pin_self": "ddb4b8ba9c04223a6f76db3fdb1758f33cb79ceabf8ea6d1a08a42dd308149e7"
                 }
             ]
         },

--- a/flixkit/v1_1/types_test.go
+++ b/flixkit/v1_1/types_test.go
@@ -15,18 +15,18 @@ var pragmaWithParameters = `
 	title: "Update Greeting",
 	description: "Update the greeting on the HelloWorld contract",
 	language: "en-US",
-	parameters: [
-		Parameter(
-			name: "greeting", 
-			title: "Greeting", 
-			description: "The greeting to set on the HelloWorld contract"
-		),
-		Parameter(
-			name: "amount", 
-			title: "Amount", 
-			description: "The amount parameter to Test"
-		)
-	],
+)
+
+#interaction_param_greeting(
+	title: "Greeting",
+	description: "The greeting to set on the HelloWorld contract",
+	language: "en-US",
+)
+
+#interaction_param_amount(
+	title: "Amount",
+	description: "The amount parameter to Test",
+	language: "en-US",
 )
 
 import "HelloWorld"

--- a/flixkit/v1_1/types_test.go
+++ b/flixkit/v1_1/types_test.go
@@ -281,7 +281,7 @@ func TestGenerateTemplateIdWithDeps(t *testing.T) {
 				}
 			],
 			"cadence": {
-				"body": "import \"HelloWorld\"\n\n#interaction (\n  version: \"1.1.0\",\n\ttitle: \"Update Greeting\",\n\tdescription: \"Update the greeting on the HelloWorld contract\",\n\tlanguage: \"en-US\",\n\tparameters: [\n\t\tParameter(\n\t\t\tname: \"greeting\", \n\t\t\ttitle: \"Greeting\", \n\t\t\tdescription: \"The greeting to set on the HelloWorld contract\"\n\t\t)\n\t],\n)\ntransaction(greeting: String) {\n\n  prepare(acct: AuthAccount) {\n    log(acct.address)\n  }\n\n  execute {\n    HelloWorld.updateGreeting(newGreeting: greeting)\n  }\n}\n",
+				"body": "import \"HelloWorld\"\n\n#interaction (\n  version: \"1.1.0\",\n\ttitle: \"Update Greeting\",\n\tdescription: \"Update the greeting on the HelloWorld contract\",\n\tlanguage: \"en-US\",\n)\ntransaction(greeting: String) {\n\n  prepare(acct: AuthAccount) {\n    log(acct.address)\n  }\n\n  execute {\n    HelloWorld.updateGreeting(newGreeting: greeting)\n  }\n}\n",
 				"network_pins": [
 					{
 						"network": "testnet",


### PR DESCRIPTION
Update Cadence pragma processing:

Nested structures are not supported at runtime, which cases issues executing flix. Remove processing nested structures. Process parameter specific pragmas to populate metadata for parameters.

This is not a breaking change, old pragma will still get processed but won't pull out any nested parameters information. The cadence will need to be changed. User will need to update the pragma to have valid Cadence.

