### PR TITLE
Handle errors from GetLatestBlock

### DIFF
--- a/internal/v1_1/generator.go
+++ b/internal/v1_1/generator.go
@@ -214,7 +214,10 @@ func (g *Generator) generateDependenceInfo(ctx context.Context, contractName str
 		}
 		flowkit := getNetworkClient(n.Network, g.clients)
 		if n.DependencyPinBlockHeight == 0 && flowkit != nil {
-			block, _ := flowkit.Gateway().GetLatestBlock(ctx)
+			block, err := flowkit.Gateway().GetLatestBlock(ctx)
+			if err != nil {
+				return nil, err
+			}
 			height := block.Height
 
 			details, err := g.GenerateDepPinDepthFirst(ctx, flowkit, n.Address, contractName, height)


### PR DESCRIPTION
## Description

Previously I encountered a runtime panic when trying to generate FLIX templates in flow-core-contracts repo:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x101eb4374]

goroutine 1 [running]:
github.com/onflow/flixkit-go/internal/v1_1.(*Generator).generateDependenceInfo(0x140011b31d8, {0x102e9b3a0, 0x1044c3d00}, {0x140015e0e20, 0xd})
        /Users/bartkozorog/Projects/flixkit-go/internal/v1_1/generator.go:222 +0x244
github.com/onflow/flixkit-go/internal/v1_1.Generator.processDependencies({{0x140008bc688, 0x15, 0x23}, {0x140015ca5c0, 0x5, 0x8}, 0x14001986270}, {0x102e9b3a0, 0x1044c3d00}, 0x1020f65c6?)
        /Users/bartkozorog/Projects/flixkit-go/internal/v1_1/generator.go:181 +0x100
github.com/onflow/flixkit-go/internal/v1_1.Generator.CreateTemplate({{0x140008bc688, 0x15, 0x23}, {0x140015ca5c0, 0x5, 0x8}, 0x14001986270}, {0x102e9b3a0, 0x1044c3d00}, {0x14001216c00, ...}, ...)
        /Users/bartkozorog/Projects/flixkit-go/internal/v1_1/generator.go:126 +0x198
github.com/onflow/flixkit-go/internal.flixService.CreateTemplate({0x140010e1140?}, {0x102e9b3a0, 0x1044c3d00}, 0x140016738f0, {0x14001216c00, 0x3d9}, {0x0?, 0x10106b3e0?}, {0x14000b3c780, 0x5, ...})
        /Users/bartkozorog/Projects/flixkit-go/internal/flix_service.go:201 +0xf8
github.com/onflow/flow-cli/internal/super.generateFlixCmd({_, _, _}, {{0x0, 0x0}, {0x1020db9f2, 0x4}, {0x16f8473c9, 0x8e}, {0x0, ...}, ...}, ...)
        /Users/bartkozorog/Projects/flow-cli/internal/super/flix.go:259 +0x32c
github.com/onflow/flow-cli/internal/super.generateCmd({0x14001602b40, 0x1, 0x3}, {{0x0, 0x0}, {0x1020db9f2, 0x4}, {0x16f8473c9, 0x8e}, {0x0, ...}, ...}, ...)
        /Users/bartkozorog/Projects/flow-cli/internal/super/flix.go:207 +0x11c
github.com/onflow/flow-cli/internal/command.Command.AddToParent.func1(0x140015db700?, {0x14001602b40, 0x1, 0x3})
        /Users/bartkozorog/Projects/flow-cli/internal/command/command.go:144 +0x4cc
github.com/spf13/cobra.(*Command).execute(0x104321e20, {0x1400004e210, 0x3, 0x3})
        /Users/bartkozorog/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0x828
github.com/spf13/cobra.(*Command).ExecuteC(0x14000cbc908)
        /Users/bartkozorog/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/bartkozorog/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
main.main()
        /Users/bartkozorog/Projects/flow-cli/cmd/flow/main.go:129 +0xc34

````

Now when the error is handled, it's clear what the issue is:

```
❌  Error while dialing: dial tcp 127.0.0.1:3569: connect: connection refused" 
🙏 Make sure your emulator is running or connection address is correct.

```